### PR TITLE
fix up formatting a little

### DIFF
--- a/holynotes/components/modals/HelpModal.tsx
+++ b/holynotes/components/modals/HelpModal.tsx
@@ -7,8 +7,8 @@
 import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
 import { findByProps } from "@webpack";
 import { Button, Forms, Text } from "@webpack/common";
-import noteHandler from "plugins/holynotes/noteHandler";
-import { downloadNotes, uploadNotes } from "plugins/holynotes/utils";
+import noteHandler from "../../noteHandler";
+import { downloadNotes, uploadNotes } from "../../utils";
 
 export default ({ onClose, ...modalProps }: ModalProps & { onClose: () => void; }) => {
     const { colorStatusGreen } = findByProps("colorStatusGreen");

--- a/holynotes/components/modals/Notebook.tsx
+++ b/holynotes/components/modals/Notebook.tsx
@@ -9,8 +9,8 @@ import { classes } from "@utils/misc";
 import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
 import { findByProps } from "@webpack";
 import { ContextMenuApi, Flex, FluxDispatcher, Menu, React, Text, TextInput } from "@webpack/common";
-import noteHandler from "plugins/holynotes/noteHandler";
-import { HolyNotes } from "plugins/holynotes/types";
+import noteHandler from "../../noteHandler";
+import { HolyNotes } from "../../types";
 
 import HelpIcon from "../icons/HelpIcon";
 import Errors from "./Error";

--- a/holynotes/components/modals/NotebookCreateModal.tsx
+++ b/holynotes/components/modals/NotebookCreateModal.tsx
@@ -6,7 +6,7 @@
 
 import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
 import { Button, React, Text, TextInput } from "@webpack/common";
-import noteHandler from "plugins/holynotes/noteHandler";
+import noteHandler from "../../noteHandler";
 
 export default (props: ModalProps & { onClose: () => void }) => {
     const [notebookName, setNotebookName] = React.useState("");

--- a/holynotes/components/modals/NotebookDeleteModal.tsx
+++ b/holynotes/components/modals/NotebookDeleteModal.tsx
@@ -7,7 +7,7 @@
 import ErrorBoundary from "@components/ErrorBoundary";
 import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
 import { Button, React, Text } from "@webpack/common";
-import noteHandler from "plugins/holynotes/noteHandler";
+import noteHandler from "../../noteHandler";
 
 import Error from "./Error";
 import { RenderMessage } from "./RenderMessage";

--- a/holynotes/components/modals/RenderMessage.tsx
+++ b/holynotes/components/modals/RenderMessage.tsx
@@ -8,8 +8,8 @@ import { classes } from "@utils/misc";
 import { ModalProps } from "@utils/modal";
 import { findByCode, findByProps } from "@webpack";
 import { Clipboard, ContextMenuApi, FluxDispatcher, Menu, NavigationRouter, React } from "@webpack/common";
-import noteHandler from "plugins/holynotes/noteHandler";
-import { HolyNotes } from "plugins/holynotes/types";
+import noteHandler from "../../noteHandler";
+import { HolyNotes } from "../../types";
 
 
 export const RenderMessage = ({


### PR DESCRIPTION
the plugin was hardcoded to go into the plugins folder 
but normally your third party plugins are supposed to be put into the [userplugins](https://github.com/Vendicated/Vencord/blob/main/docs/2_PLUGINS.md#plugin-entrypoint) folder, i used relative paths to get the right imports.
i dont normally do anything javascript so i hope this was a good pr :3

TL;DR, fixed the bug where it wouldn't build with vencord